### PR TITLE
hotfix: Error en las solicitudes, no persistian las cookies por lo qu…

### DIFF
--- a/src/infrastructure/ConductorApiRepository.ts
+++ b/src/infrastructure/ConductorApiRepository.ts
@@ -1,6 +1,19 @@
-import axios from "axios";
-import type { Conductor } from "../domain/entities/Conductor";
-import type { ConductorRepository } from "../domain/repositories/ConductorRepository";
+import axios from 'axios';
+import type { Conductor } from '../domain/entities/Conductor';
+import type { ConductorRepository } from '../domain/repositories/ConductorRepository';
+
+/**
+ * Cliente HTTP principal.
+ *
+ * withCredentials es obligatorio porque la autenticación
+ * usa cookies httpOnly con JWT.
+ *
+ * No se define baseURL porque el frontend y backend
+ * ya están detrás del mismo dominio/proxy en producción.
+ */
+const api = axios.create({
+  withCredentials: true,
+});
 
 type ApiSuccess<T> = {
   status?: string;
@@ -8,39 +21,63 @@ type ApiSuccess<T> = {
   message?: string;
 };
 
+/**
+ * Convierte una fila cruda del backend
+ * al modelo Conductor del frontend.
+ */
 function mapRow(raw: Record<string, unknown>): Conductor {
   return {
-    cedula: String(raw.cedula ?? ""),
-    nombre: String(raw.nombre ?? ""),
-    correo_electronico: String(raw.correo_electronico ?? ""),
-    telefono: String(raw.telefono ?? ""),
+    cedula: String(raw.cedula ?? ''),
+    nombre: String(raw.nombre ?? ''),
+    correo_electronico: String(raw.correo_electronico ?? ''),
+    telefono: String(raw.telefono ?? ''),
     estado: raw.estado != null ? String(raw.estado) : undefined,
   };
 }
 
+/**
+ * Extrae y transforma la lista de conductores.
+ */
 function unwrapList(res: unknown): Conductor[] {
   const body = res as ApiSuccess<Record<string, unknown>[]>;
   const list = Array.isArray(body.data) ? body.data : [];
-  return list.map((row) => mapRow(row));
+
+  return list.map(mapRow);
 }
 
+/**
+ * Normaliza errores HTTP y de red.
+ */
 function apiErrorMessage(err: unknown): string {
   if (!axios.isAxiosError(err) || !err.response?.data) {
-    return err instanceof Error ? err.message : "Error de red";
+    return err instanceof Error ? err.message : 'Error de red';
   }
-  const d = err.response.data as { errors?: string[]; message?: string };
-  if (Array.isArray(d.errors) && d.errors.length) return d.errors.join(" ");
-  if (typeof d.message === "string") return d.message;
+
+  const data = err.response.data as {
+    errors?: string[];
+    message?: string;
+  };
+
+  if (Array.isArray(data.errors) && data.errors.length) {
+    return data.errors.join(' ');
+  }
+
+  if (typeof data.message === 'string') {
+    return data.message;
+  }
+
   return `Error ${err.response.status}`;
 }
 
-/** Persistencia real contra buscali-backend (`/api/v1/conductores`). Requiere sesión (cookie tras login). */
+/**
+ * Repositorio de conductores conectado al backend.
+ */
 export class ConductorApiRepository implements ConductorRepository {
   async getAll(): Promise<Conductor[]> {
     try {
-      const { data } = await axios.get<ApiSuccess<Record<string, unknown>[]>>(
-        "/api/v1/conductores"
-      );
+      const { data } =
+        await api.get<ApiSuccess<Record<string, unknown>[]>>('/conductores');
+
       return unwrapList(data);
     } catch (e) {
       throw new Error(apiErrorMessage(e));
@@ -48,17 +85,18 @@ export class ConductorApiRepository implements ConductorRepository {
   }
 
   async save(conductor: Conductor): Promise<void> {
-    const telefono = conductor.telefono.replace(/\D/g, "");
-    const cedula = conductor.cedula.replace(/\D/g, "");
-    const estado =
-      conductor.estado === "Inactivo" ? "Inactivo" : "Activo";
+    const telefono = conductor.telefono.replace(/\D/g, '');
+    const cedula = conductor.cedula.replace(/\D/g, '');
+
+    const estado = conductor.estado === 'Inactivo' ? 'Inactivo' : 'Activo';
+
     try {
-      await axios.post("/api/v1/conductores", {
+      await api.post('/conductores', {
         cedula,
         nombre: conductor.nombre.trim(),
         correo_electronico: conductor.correo_electronico.trim(),
         telefono,
-        contrasena: conductor.contrasena ?? "",
+        contrasena: conductor.contrasena ?? '',
         aceptaTerminos: true,
         estado,
       });
@@ -69,29 +107,40 @@ export class ConductorApiRepository implements ConductorRepository {
 
   async delete(cedula: string): Promise<void> {
     try {
-      await axios.delete(
-        `/api/v1/conductores/${encodeURIComponent(cedula)}`
-      );
+      await api.delete(`/conductores/${encodeURIComponent(cedula)}`);
     } catch (e) {
       throw new Error(apiErrorMessage(e));
     }
   }
 
   async update(conductor: Conductor): Promise<void> {
-    const telefono = conductor.telefono.replace(/\D/g, "");
-    const estado: "Activo" | "Inactivo" =
-      conductor.estado === "Inactivo" ? "Inactivo" : "Activo";
+    const telefono = conductor.telefono.replace(/\D/g, '');
+
+    const estado: 'Activo' | 'Inactivo' =
+      conductor.estado === 'Inactivo' ? 'Inactivo' : 'Activo';
+
     const body: Record<string, string> = {};
+
     const nombre = conductor.nombre.trim();
-    if (nombre) body.nombre = nombre;
-    const mail = conductor.correo_electronico.trim();
-    if (mail) body.correo_electronico = mail;
-    if (telefono) body.telefono = telefono;
+    if (nombre) {
+      body.nombre = nombre;
+    }
+
+    const correo = conductor.correo_electronico.trim();
+    if (correo) {
+      body.correo_electronico = correo;
+    }
+
+    if (telefono) {
+      body.telefono = telefono;
+    }
+
     body.estado = estado;
+
     try {
-      await axios.put(
-        `/api/v1/conductores/${encodeURIComponent(conductor.cedula)}`,
-        body
+      await api.put(
+        `/conductores/${encodeURIComponent(conductor.cedula)}`,
+        body,
       );
     } catch (e) {
       throw new Error(apiErrorMessage(e));


### PR DESCRIPTION
# Corrección de autenticación basada en cookies JWT

## Descripción

Se corrigió el manejo de autenticación entre frontend y backend para permitir el envío correcto de cookies `httpOnly` con JWT en las solicitudes protegidas.

El problema principal era que Axios no estaba enviando credenciales (`cookies`) en las peticiones HTTP, por lo que el backend no recibía `access_token` en `req.cookies`.

---

# Cambios realizados

## Frontend

### Configuración global de Axios

Se creó una instancia de Axios con:

```ts id="q1v5v5"
withCredentials: true
```

Esto permite que el navegador envíe automáticamente las cookies de sesión en cada request autenticada.

---

### Eliminación de rutas repetidas

Se removió `/api/v1` de las solicitudes del repositorio, dejando rutas más limpias:

Antes:

```ts id="hz0o2i"
"/api/v1/conductores"
```

Ahora:

```ts id="1im6ff"
"/conductores"
```

La resolución de rutas queda delegada al proxy o gateway configurado en producción.

---

### Refactor y limpieza del repositorio

Se mejoró:

* organización del archivo
* comentarios
* manejo de errores
* reutilización del cliente HTTP

---

# Resultado

Ahora:

* el navegador conserva la cookie JWT
* las requests autenticadas envían correctamente `access_token`
* las rutas protegidas funcionan correctamente en producción

---

# Consideraciones

El frontend y backend deben compartir:

* mismo dominio o subdominio válido
* configuración correcta de CORS
* cookies compatibles con entorno productivo (`secure`, `sameSite`)
